### PR TITLE
Update Http.js

### DIFF
--- a/lib/Lib/Core/Http.js
+++ b/lib/Lib/Core/Http.js
@@ -146,7 +146,7 @@ var Http = module.exports = Class(function(){
           }
           for(var name in post){
             //单个表单值长度超过限制
-            if (post[name].length > C('post_max_fields_size')) {
+            if (post[name] && post[name].length > C('post_max_fields_size')) {
               self.res.statusCode = 413;
               self.http.end();
               return;


### PR DESCRIPTION
commonPost方法在遍历Post参数时 取post[name].length 如果有参数null会报错。