### PR TITLE
controller.base.fetch pass config to view.fetch

### DIFF
--- a/src/controller/base.js
+++ b/src/controller/base.js
@@ -227,9 +227,9 @@ export default class extends think.http.base {
    * @param  {String} templateFile [template filepath]
    * @return {promise}              []
    */
-  fetch(templateFile, data) {
+  fetch(templateFile, data, config) {
     this._baseAssign();
-    return this.view().fetch(templateFile, data);
+    return this.view().fetch(templateFile, data, config);
   }
   /**
    * display template


### PR DESCRIPTION
common使用base/ejs, home使用jade的时候, 404.html变成使用jade渲染报错
查看到error.js有传options, view.fetch有接收config, base.fetch中转的时候忽略了,实测加上就可以了