### PR TITLE
修复与socket.io c++ client通信失败的问题

### DIFF
--- a/src/adapter/websocket/socket.io.js
+++ b/src/adapter/websocket/socket.io.js
@@ -133,7 +133,7 @@ export default class extends Base {
     if(!request.res){
         http = await think.http(url);
     }else{
-        let http = await think.http(request, think.extend({}, request.res));
+        http = await think.http(request, think.extend({}, request.res));
     }
     http.data = data;
     http.socket = socket;

--- a/src/adapter/websocket/socket.io.js
+++ b/src/adapter/websocket/socket.io.js
@@ -128,8 +128,13 @@ export default class extends Base {
       url = `/${url}`;
     }
     request.url = url;
-
-    let http = await think.http(request, think.extend({}, request.res));
+    let http;
+    //socket.io c++ client发过来的requet没有res
+    if(!request.res){
+        http = await think.http(url);
+    }else{
+        let http = await think.http(request, think.extend({}, request.res));
+    }
     http.data = data;
     http.socket = socket;
     http.io = this.io;


### PR DESCRIPTION
实践过程中发现c++版本的client通信时request.res为undefined,导致http构造不成功,action无法触发