### PR TITLE
fix postgresql idle connection closed determination

### DIFF
--- a/src/adapter/socket/postgresql.js
+++ b/src/adapter/socket/postgresql.js
@@ -93,7 +93,7 @@ export default class extends Base {
       return data.rows;
     }).catch(err => {
       //when socket is closed, try it
-      if(err.message === 'This socket is closed.'){
+        if(err.code === 'EPIPE'){
         this.close();
         return this.query(sql);
       }


### PR DESCRIPTION
Every after 8 hours, some idle connections in the connection pool gets closed. So we need to re-connect the remote server. However, the original code determine whether to re-connect based on the error message which is variable on different machine and platform. So we changed it to determine based on error code which is much more accurate!