### PR TITLE
session设置memory模式timeout无效

### DIFF
--- a/src/adapter/session/memory.js
+++ b/src/adapter/session/memory.js
@@ -43,7 +43,7 @@ export default class extends think.adapter.base {
       if(Date.now() > data.expire){
         return this.store.delete(this.cookie);
       }
-      data.expire = Date.now() * this.timeout * 1000;
+      data.expire = Date.now() + this.timeout * 1000;
       let value = data.data;
       if(name){
         return think.clone(value[name]);


### PR DESCRIPTION
session设置memory模式时，timeout设置无效，修改了memory.js中的get方法，将Date.now() * 改成了
Date.now() +