### PR TITLE
fix the escape problem on PostgreSQL

### DIFF
--- a/src/adapter/db/postgresql.js
+++ b/src/adapter/db/postgresql.js
@@ -96,7 +96,7 @@ export default class extends Base {
    */
   parseValue(value){
     if (think.isString(value)) {
-      value = '\'' + this.escapeString(value) + '\'';
+      value = 'E\'' + this.escapeString(value) + '\'';
     }else if(think.isArray(value)){
       if (/^exp$/.test(value[0])) {
         value = value[1];


### PR DESCRIPTION
PostgreSQL also accepts "escape" string constants, which are an extension to the SQL standard. An escape string constant is specified by writing the letter E (upper or lower case) just before the opening single quote, e.g., E'foo'