### PR TITLE
删除 prefix 默认值

### DIFF
--- a/src/config/db.js
+++ b/src/config/db.js
@@ -10,7 +10,7 @@ export default {
   database: '',
   user: '',
   password: '',
-  prefix: 'think_',
+  prefix: '',
   encoding: 'utf8',
   nums_per_page: 10,
   log_sql: false,


### PR DESCRIPTION
框架默认带 thinkjs_ 前缀  我觉得这个挺不合理的，默认配置应该是相对比较干净的，并且前缀不是很多人都在使用吧？