### PR TITLE
Extract babel options from package.json to .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": ["es2015-loose", "stage-1"],
+  "plugins": ["transform-runtime"],
+  "sourceMaps": true
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "npm run eslint && npm run test-cov",
     "test-cov": "istanbul cover ./node_modules/mocha/bin/_mocha -- -t 50000 --recursive  -R spec test/",
-    "compile": "babel --presets es2015-loose,stage-1 --plugins transform-runtime src/ --out-dir lib/ --source-maps",
+    "compile": "babel src/ --out-dir lib/",
     "watch-compile": "npm run compile -- --watch",
     "watch": "npm run watch-compile",
     "prepublish": "npm run compile",
@@ -21,16 +21,16 @@
   "contributors": [{
     "name": "welefen",
     "email": "welefen@gmail.com"
-  },{
+  }, {
     "name": "im-kulikov",
     "email": "im@kulikov.im"
-  },{
+  }, {
     "name": "maxzhang",
     "email": "zhangdaiping@gmail.com"
-  },{
+  }, {
     "name": "akira-cn",
     "email": "akira.cn@gmail.com"
-  },{
+  }, {
     "name": "qgy18",
     "email": "quguangyu@gmail.com"
   }],

--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": ["es2015-loose", "stage-1"],
+  "plugins": ["transform-runtime"],
+  "sourceMaps": true
+}

--- a/template/package_es.json
+++ b/template/package_es.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "node www/development.js",
-    "compile": "babel --presets es2015-loose,stage-1 --plugins transform-runtime src/ --out-dir app/ --source-maps",
+    "compile": "babel src/ --out-dir app/",
     "watch-compile": "node -e \"console.log('<npm run watch-compile> no longer need, use <npm start> command direct.');console.log();\"",
     "watch": "npm run watch-compile"
   },

--- a/template/package_test_es.json
+++ b/template/package_test_es.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "node www/development.js",
-    "compile": "babel --presets es2015-loose,stage-1 --plugins transform-runtime src/ --out-dir app/ --source-maps",
+    "compile": "babel src/ --out-dir app/",
     "watch-compile": "node -e \"console.log('<npm run watch-compile> no longer need, use <npm start> command direct.');console.log();\"",
     "watch": "npm run watch-compile",
     "test": "istanbul cover ./node_modules/mocha/bin/_mocha -- -t 10000 --recursive  -R spec test/"

--- a/template/plugin/.babelrc
+++ b/template/plugin/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": ["es2015-loose", "stage-1"],
+  "plugins": ["transform-runtime"],
+  "sourceMaps": true,
+  "retainLines": true
+}

--- a/template/plugin/package.json
+++ b/template/plugin/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha --reporter spec --timeout 5000 --recursive test/",
     "test-cov": "istanbul cover ./node_modules/mocha/bin/_mocha -- -t 5000 --recursive  -R spec test/",
-    "compile": "babel --presets es2015-loose,stage-1 --plugins transform-runtime src/ --out-dir lib/ --retain-lines",
+    "compile": "babel src/ --out-dir lib/",
     "watch-compile": "npm run compile -- --watch",
     "prepublish": "npm run compile",
     "eslint": "eslint src/"


### PR DESCRIPTION
由于通过 `thinkjs new test` 方式创建项目，根目录下没有 .babelrc 配置文件，会导致编译时 babel 向上一级目录搜索 .babelrc 文件，这样存在一些风险，比如上一级目录（跟 <project> 目录同级）的 .babelrc 文件存在不相关的配置时，在编译实际项目时会报错，报错原因比较隐晦难以查找。我搜索了下 thinkjs 整个源代码，把 babel 相关的选项提取到 .babelrc 文件。

目录示意：
|-`.babelrc`
|-**test**
|--package.json
