### PR TITLE
修复数据库返回字段只有下划线（aa_bb_cc）方式的问题

### DIFF
--- a/src/config/db.js
+++ b/src/config/db.js
@@ -15,6 +15,7 @@ export default {
   nums_per_page: 10,
   log_sql: false,
   log_connect: true,
+  camel_case: true,
   cache: {
     on: true,
     type: '',

--- a/src/core/think.js
+++ b/src/core/think.js
@@ -816,7 +816,7 @@ think.cache = async (name, value, options) => {
     return data;
   }
   //set cache
-  return instance.set(name, value, options.timeout);
+  return instance.set(name, value);
 };
 
 

--- a/src/core/think.js
+++ b/src/core/think.js
@@ -138,7 +138,7 @@ think.base = base;
  */
 think.snakeCase = (str) => {
   return str.replace(/([^A-Z])([A-Z])/g, function ($0, $1, $2) {
-    return $1 + "_" + $2.toLowerCase();
+    return $1 + '_' + $2.toLowerCase();
   });
 };
 /**

--- a/src/core/think.js
+++ b/src/core/think.js
@@ -133,6 +133,15 @@ think.module = [];
  */
 think.base = base;
 /**
+ * snakeCase string
+ * @param str
+ */
+think.snakeCase = (str) => {
+  return str.replace(/([^A-Z])([A-Z])/g, function ($0, $1, $2) {
+    return $1 + "_" + $2.toLowerCase();
+  });
+};
+/**
  * reject promise
  * @param  {[type]} err []
  * @return {[type]}     []
@@ -807,7 +816,7 @@ think.cache = async (name, value, options) => {
     return data;
   }
   //set cache
-  return instance.set(name, value);
+  return instance.set(name, value, options.timeout);
 };
 
 

--- a/src/model/base.js
+++ b/src/model/base.js
@@ -163,9 +163,11 @@ export default class extends Base {
 	    // 把where也修改了
         let where = options.where;
         options.where = {};
-        let keyArray = Object.keys(where);
-        for (let key of keyArray) {
-          options.where[think.snakeCase(key)] = where[key];
+        if(!think.isEmpty(where)){
+          let keyArray = Object.keys(where);
+          for (let key of keyArray) {
+            options.where[think.snakeCase(key)] = where[key];
+          }
         }
 	  }
 

--- a/src/model/base.js
+++ b/src/model/base.js
@@ -1,7 +1,10 @@
 'use strict';
 
+const config = think.config('db');
 import util from 'util';
 import Base from './_base.js';
+
+
 
 /**
  * model base class
@@ -94,11 +97,12 @@ export default class extends Base {
     return '( ' + sql + ' )';
   }
   /**
-   * parse options
-   * @param  {Object} options []
-   * @return promise         []
+   * 解析options
+   * @param oriOpts 源options
+   * @param extraOptions 附加options
+   * @param flag 为了防止add、update数据时做一次无谓的循环而做的一个控制(默认true)
    */
-  async parseOptions(oriOpts, extraOptions){
+  async parseOptions(oriOpts, extraOptions, flag = true){
     let options = think.extend({}, this._options);
     if (think.isObject(oriOpts)) {
       options = think.extend(options, oriOpts);
@@ -135,6 +139,36 @@ export default class extends Base {
         }
       }
     }
+
+    // 是否使用驼峰式
+    let camelCase = config.camel_case || false;
+	  if(camelCase){
+	    // 修改thinkjs的model，把field全部转为驼峰式
+	    if(flag){
+          if(think.isEmpty(options.field)){
+            options.field = [];
+            let keyArray = Object.keys(schema);
+            for (let key of keyArray) {
+              options.field.push(util.format('`%s` AS `%s`', key, think.camelCase(key)));
+            }
+          } else {
+            let fields = options.field;
+            options.field = [];
+            for (let field of fields) {
+              options.field.push(util.format('`%s` AS `%s`', field, think.camelCase(field)));
+            }
+          }
+	    }
+
+	    // 把where也修改了
+        let where = options.where;
+        options.where = {};
+        let keyArray = Object.keys(where);
+        for (let key of keyArray) {
+          options.where[think.snakeCase(key)] = where[key];
+        }
+	  }
+
     //field reverse
     if(options.field && options.fieldReverse){
       //reset fieldReverse value
@@ -188,6 +222,16 @@ export default class extends Base {
    * @return {}      []
    */
   parseData(data){
+  	//如果使用驼峰式，在这里转为下划线
+	  let camelCase = config.camel_case || false;
+	  if(camelCase){
+	  	let tmpData = data;
+		  data={};
+		  let keyArray = Object.keys(tmpData);
+		  for (let key of keyArray) {
+			  data[think.snakeCase(key)] = tmpData[key];
+		  }
+	  }
     //deep clone data
     data = think.extend({}, data);
     for(let key in data){
@@ -217,7 +261,7 @@ export default class extends Base {
     //clear data
     this._data = {};
 
-    options = await this.parseOptions(options);
+    options = await this.parseOptions(options,{},false);
 
     let parsedData = this.parseData(data);
     parsedData = await this.beforeAdd(parsedData, options);
@@ -273,7 +317,7 @@ export default class extends Base {
       replace = true;
       options = {};
     }
-    options = await this.parseOptions(options);
+    options = await this.parseOptions(options,{},false);
     let promises = data.map(item => {
       item = this.parseData(item);
       return this.beforeAdd(item, options);
@@ -320,7 +364,7 @@ export default class extends Base {
     //clear data
     this._data = {};
 
-    options = await this.parseOptions(options);
+    options = await this.parseOptions(options,{},false);
 
     let parsedData = this.parseData(data);
 

--- a/src/model/base.js
+++ b/src/model/base.js
@@ -100,9 +100,9 @@ export default class extends Base {
    * 解析options
    * @param oriOpts 源options
    * @param extraOptions 附加options
-   * @param flag 为了防止add、update数据时做一次无谓的循环而做的一个控制(默认true)
+   * @param flag 如果是add、update方法一定要判断是否需要转驼峰(默认false)
    */
-  async parseOptions(oriOpts, extraOptions, flag = true){
+  async parseOptions(oriOpts, extraOptions, flag = false){
     let options = think.extend({}, this._options);
     if (think.isObject(oriOpts)) {
       options = think.extend(options, oriOpts);
@@ -140,27 +140,27 @@ export default class extends Base {
       }
     }
 
-    // 是否使用驼峰式
-    let camelCase = config.camel_case || false;
-	  if(camelCase){
-	    // 修改thinkjs的model，把field全部转为驼峰式
-	    if(flag){
-          if(think.isEmpty(options.field)){
-            options.field = [];
-            let keyArray = Object.keys(schema);
-            for (let key of keyArray) {
-              options.field.push(util.format('`%s` AS `%s`', key, think.camelCase(key)));
-            }
-          } else {
-            let fields = options.field;
-            options.field = [];
-            for (let field of fields) {
-              options.field.push(util.format('`%s` AS `%s`', field, think.camelCase(field)));
-            }
+    // 如果是add、update方法一定要判断是否需要转驼峰
+    if(flag){
+      // 是否使用驼峰式
+      let camelCase = config.camel_case || false;
+      if(camelCase){
+        if(think.isEmpty(options.field)){
+          options.field = [];
+          let keyArray = Object.keys(schema);
+          for (let key of keyArray) {
+            options.field.push(util.format('`%s` AS `%s`', key, think.camelCase(key)));
           }
-	    }
+        } else {
+          // 因为要转驼峰式，所以select * 的话就把每一个字段都转一次
+          let fields = options.field;
+          options.field = [];
+          for (let field of fields) {
+            options.field.push(util.format('`%s` AS `%s`', field, think.camelCase(field)));
+          }
+        }
 
-	    // 把where也修改了
+        // 如果where有条件的话把where也修改了
         let where = options.where;
         options.where = {};
         if(!think.isEmpty(where)){
@@ -169,7 +169,8 @@ export default class extends Base {
             options.where[think.snakeCase(key)] = where[key];
           }
         }
-	  }
+      }
+    }
 
     //field reverse
     if(options.field && options.fieldReverse){
@@ -263,7 +264,7 @@ export default class extends Base {
     //clear data
     this._data = {};
 
-    options = await this.parseOptions(options,{},false);
+    options = await this.parseOptions(options, {}, true);
 
     let parsedData = this.parseData(data);
     parsedData = await this.beforeAdd(parsedData, options);
@@ -319,7 +320,7 @@ export default class extends Base {
       replace = true;
       options = {};
     }
-    options = await this.parseOptions(options,{},false);
+    options = await this.parseOptions(options, {}, true);
     let promises = data.map(item => {
       item = this.parseData(item);
       return this.beforeAdd(item, options);
@@ -366,7 +367,7 @@ export default class extends Base {
     //clear data
     this._data = {};
 
-    options = await this.parseOptions(options,{},false);
+    options = await this.parseOptions(options, {}, true);
 
     let parsedData = this.parseData(data);
 

--- a/test/core/think.js
+++ b/test/core/think.js
@@ -175,6 +175,10 @@ describe('core/think.js', function(){
     assert.equal(think.isHttp({}), false);
     assert.equal(think.isHttp({req: {}, res: {}}), true);
   })
+  it('think.snakeCase', function(){
+    assert.equal(think.snakeCase('snakeCase'), 'snake_case');
+    assert.equal(think.snakeCase('snake_case'), 'snake_case');
+  })
   it('think.co is function', function(){
     assert.equal(typeof think.co, 'function');
     assert.equal(typeof think.co.wrap, 'function');

--- a/test/model/base.js
+++ b/test/model/base.js
@@ -375,7 +375,7 @@ describe('model/base.js', function(){
   })
   it('build sql', function(done){
     instance.where('id=1').field('name,title').group('name').limit(10).buildSql().then(function(sql){
-      assert.equal(sql, '( SELECT `name`,`title` FROM `think_user` WHERE ( id=1 ) GROUP BY `name` LIMIT 10 )')
+      assert.equal(sql, '( SELECT `name`,`title` FROM `think_user` WHERE ( id=1 ) GROUP BY `name` LIMIT 10 )');
       done();
     })
   })


### PR DESCRIPTION
原有的老项目用的是java，数据库定义的字段为下划线（aa_bb_cc）方式，返回给客户端的字段为驼峰式。现在新的需求用thinkjs实现，我们使用thinkjs是直接由model层获取得数据然后返回，由于数据库定义的是下划线，所以node实现的接口与java返回的数据格式不一致。为了解决这个问题，我在config/db.js加了一个配置camel_case选项，修改model/base.js的parseOptions方法和parseData方法，使其支持返回的字段是下划线( snakeCase )or驼峰式( camelCase )。